### PR TITLE
Implement support for request cancellation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,7 +92,7 @@ func startServer() error {
 	}()
 
 	if serverCfg.EnablePprof {
-		debug := &fasthttp.Server{Name: "debug", Handler: web.Debug(log, cfg)}
+		debug := &fasthttp.Server{Name: "debug", Handler: web.Debug(log)}
 		go func() {
 			log.Info("api debug listing", "port", serverCfg.PropfAddr)
 			serverErrors <- debug.ListenAndServe(":" + serverCfg.PropfAddr)

--- a/internal/platform/web/health.go
+++ b/internal/platform/web/health.go
@@ -14,7 +14,7 @@ func newCheck(build string) check {
 }
 
 func (c check) Health(ctx *fasthttp.RequestCtx) error {
-	ctx.Response.SetBodyString("I'm healthy! :)")
+	ctx.Response.SetBodyString("I'contextIndex healthy! :)")
 	return nil
 }
 

--- a/internal/platform/web/middleware/conn_manager.go
+++ b/internal/platform/web/middleware/conn_manager.go
@@ -1,0 +1,95 @@
+package middleware
+
+import (
+	"context"
+	"github.com/b2wdigital/restQL-golang/v4/pkg/restql"
+	"io"
+	"net"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// ConnManager keeps track of active TCP connections
+// and their corresponding contexts.
+//
+// When a connection is closed by the client it cancel
+// its context.
+type ConnManager struct {
+	log          restql.Logger
+	contextIndex sync.Map
+}
+
+// NewConnManager creates a connection manager
+func NewConnManager(log restql.Logger) *ConnManager {
+	return &ConnManager{log: log}
+}
+
+// ContextForConnection get the connections context, if it exists.
+// Otherwise it create a context and start the connection watcher.
+func (cm *ConnManager) ContextForConnection(conn net.Conn) context.Context {
+	connCtx, found := cm.contextIndex.Load(conn)
+	if !found {
+		return cm.initializeConnContext(conn)
+	}
+
+	ctx, ok := connCtx.(context.Context)
+	if !ok {
+		return cm.initializeConnContext(conn)
+	}
+
+	return ctx
+}
+
+func (cm *ConnManager) initializeConnContext(conn net.Conn) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go cm.watchConn(conn, func() {
+		cm.contextIndex.Delete(conn)
+		cancel()
+	})
+
+	cm.contextIndex.Store(conn, ctx)
+
+	return ctx
+}
+
+func (cm *ConnManager) watchConn(conn net.Conn, callback func()) {
+	rc, err := conn.(syscall.Conn).SyscallConn()
+	if err != nil {
+		cm.log.Error("failed to cast connection to syscall interface", err)
+		callback()
+		return
+	}
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+
+	var sysErr error = nil
+	for {
+		select {
+		case <-ticker.C:
+			err = rc.Read(func(fd uintptr) bool {
+				var buf = []byte{0}
+				n, _, err := syscall.Recvfrom(int(fd), buf, syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
+				switch {
+				case n == 0 && err == nil:
+					sysErr = io.EOF
+				case err == syscall.EAGAIN || err == syscall.EWOULDBLOCK:
+					sysErr = nil
+				default:
+					sysErr = err
+				}
+				return true
+			})
+			if err != nil {
+				callback()
+				return
+			}
+
+			if sysErr != nil {
+				callback()
+				return
+			}
+		}
+	}
+}

--- a/internal/platform/web/middleware/native_context.go
+++ b/internal/platform/web/middleware/native_context.go
@@ -5,17 +5,21 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-type nativeContext struct{}
+type nativeContext struct {
+	cm *ConnManager
+}
 
-func newNativeContext() nativeContext {
-	return nativeContext{}
+func newNativeContext(cm *ConnManager) nativeContext {
+	return nativeContext{cm: cm}
 }
 
 func (n nativeContext) Apply(h fasthttp.RequestHandler) fasthttp.RequestHandler {
-	return func(ctx *fasthttp.RequestCtx) {
-		WithNativeContext(ctx, context.Background())
+	return func(reqCtx *fasthttp.RequestCtx) {
+		ctx := n.cm.ContextForConnection(reqCtx.Conn())
 
-		h(ctx)
+		WithNativeContext(reqCtx, ctx)
+
+		h(reqCtx)
 	}
 }
 

--- a/internal/platform/web/web.go
+++ b/internal/platform/web/web.go
@@ -1,28 +1,29 @@
 package web
 
 import (
-	"github.com/b2wdigital/restQL-golang/v4/internal/platform/conf"
-	"github.com/b2wdigital/restQL-golang/v4/internal/platform/plugins"
 	"github.com/b2wdigital/restQL-golang/v4/internal/platform/web/middleware"
 	"github.com/b2wdigital/restQL-golang/v4/pkg/restql"
 	"github.com/fasthttp/router"
 	"github.com/valyala/fasthttp"
 )
 
+type appOptions struct {
+	MiddlewareDecorator *middleware.Decorator
+}
+
 type handler func(ctx *fasthttp.RequestCtx) error
 
 type app struct {
-	config    *conf.Config
-	router    *router.Router
-	log       restql.Logger
-	lifecycle plugins.Lifecycle
+	router  *router.Router
+	log     restql.Logger
+	options appOptions
 }
 
-func newApp(log restql.Logger, config *conf.Config, pm plugins.Lifecycle) app {
+func newApp(log restql.Logger, o appOptions) app {
 	r := router.New()
 	r.NotFound = func(ctx *fasthttp.RequestCtx) { ctx.Response.SetBodyString("There is nothing here. =/") }
 
-	return app{router: r, config: config, log: log, lifecycle: pm}
+	return app{router: r, log: log, options: o}
 }
 
 func (a app) Handle(method, url string, handler handler) {
@@ -42,11 +43,11 @@ func (a app) Handle(method, url string, handler handler) {
 }
 
 func (a app) RequestHandler() fasthttp.RequestHandler {
-	mws := middleware.FetchEnabled(a.log, a.config, a.lifecycle)
-	h := middleware.Apply(a.log, a.router.Handler, mws)
-	return h
-}
+	h := a.router.Handler
+	md := a.options.MiddlewareDecorator
+	if md != nil {
+		h = md.Apply(h)
+	}
 
-func (a app) RequestHandlerWithoutMiddlewares() fasthttp.RequestHandler {
-	return a.router.Handler
+	return h
 }


### PR DESCRIPTION
This PR introduces a watching mechanism for TCP connection in order to halt the query execution when the client disconnects.

T achieve this we use a system call expose by the `syscall` package names `syscall.Recvfrom`. A basic explanation using Go can be found on this [StackOverflow answer](https://stackoverflow.com/a/58664631/5717202) and a more in-depth one [here](http://stefan.buettcher.org/cs/conn_closed.html).

This feature was validated on macOS and Linux Alpine, but not on Windows.

Also, the implementation is designed over the HTTP/1.1 limitation that a connection handles only one HTTP request at a time. In order to support HTTP/2, we will need to change the context indexes handling inside `middleware.ConnManager`.
