### PR TITLE
fix(restQL): header comparison must be case insensitive

### DIFF
--- a/internal/runner/request.go
+++ b/internal/runner/request.go
@@ -2,20 +2,21 @@ package runner
 
 import (
 	"encoding/json"
-	"github.com/b2wdigital/restQL-golang/v4/internal/domain"
-	"github.com/b2wdigital/restQL-golang/v4/pkg/restql"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/b2wdigital/restQL-golang/v4/internal/domain"
+	"github.com/b2wdigital/restQL-golang/v4/pkg/restql"
 )
 
-var disallowedHeaders = map[string]struct{}{
-	"host":            {},
-	"Content-Type":    {},
-	"Content-Length":  {},
-	"Connection":      {},
-	"Origin":          {},
-	"Accept-Encoding": {},
+var disallowedHeaders = []string{
+	"host",
+	"content-type",
+	"content-length",
+	"connection",
+	"origin",
+	"accept-encoding",
 }
 
 var queryMethodToHTTPMethod = map[string]string{
@@ -106,10 +107,19 @@ func makeHeaders(statement domain.Statement, queryCtx restql.QueryContext) map[s
 	return headers
 }
 
+func isDisallowedHeader(header string) bool {
+	for _, disallowedHeader := range disallowedHeaders {
+		if strings.EqualFold(header, disallowedHeader) {
+			return true
+		}
+	}
+	return false
+}
+
 func getForwardHeaders(queryCtx restql.QueryContext) map[string]string {
 	r := make(map[string]string)
 	for k, v := range queryCtx.Input.Headers {
-		if _, found := disallowedHeaders[k]; !found {
+		if !isDisallowedHeader(k) {
 			r[k] = v
 		}
 	}

--- a/internal/runner/resquest_test.go
+++ b/internal/runner/resquest_test.go
@@ -1,12 +1,12 @@
 package runner_test
 
 import (
-	"github.com/b2wdigital/restQL-golang/v4/pkg/restql"
 	"net/http"
 	"testing"
 
 	"github.com/b2wdigital/restQL-golang/v4/internal/domain"
 	"github.com/b2wdigital/restQL-golang/v4/internal/runner"
+	"github.com/b2wdigital/restQL-golang/v4/pkg/restql"
 	"github.com/b2wdigital/restQL-golang/v4/test"
 )
 
@@ -86,7 +86,7 @@ func TestMakeRequest(t *testing.T) {
 					"Content-Length":  "0",
 					"Connection":      "keepalive",
 					"Origin":          "www.test.com",
-					"Accept-Encoding": "gzip, deflate",
+					"accept-encoding": "gzip, deflate",
 				}},
 			},
 			restql.HTTPRequest{


### PR DESCRIPTION
This is required to be compliant with the HTTP/1.1 spec

Reference: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_casing#:~:text=When%20handling%20HTTP%2F1.1%2C%20Envoy,rely%20on%20specific%20header%20casing.