### PR TITLE
fix(conf): the 'web' namespace was renamed to 'http'

### DIFF
--- a/internal/platform/conf/yaml-defaults.go
+++ b/internal/platform/conf/yaml-defaults.go
@@ -6,7 +6,7 @@ import (
 )
 
 var defaults = []byte(`
-web:
+http:
   server:
     readTimeout: 3s
     gracefulShutdownTimeout: 1s


### PR DESCRIPTION
all the default values under 'http' were not working since the rename

for example the http.DefaultMaxIdleConnsPerHost is "2" and it's the default value of Transport's MaxIdleConnsPerHost,
by default we were reducing the application performance.