### PR TITLE
Redesign CORS middleware implementation

### DIFF
--- a/docs/restql/config.md
+++ b/docs/restql/config.md
@@ -37,18 +37,18 @@ You can use the `pprof` tool to investigate restQL performance. To enable it set
 - Health port: set through `RESTQL_HEALTH_PORT` environment variable.
 - Profiler port: set through `RESTQL_PPROF_PORT` environment variable.
 
-**Graceful shutdown**: when restQL receives a `SIGTERM` signal it starts the shutdown, avoiding accepting new requests and waiting for the ongoing ones to finish before exiting. You can define a timeout for this process using `web.server.gracefulShutdownTimeout` field in the YAML configuration, after which restQL will break all running requests and exit.
+**Graceful shutdown**: when restQL receives a `SIGTERM` signal it starts the shutdown, avoiding accepting new requests and waiting for the ongoing ones to finish before exiting. You can define a timeout for this process using `http.server.gracefulShutdownTimeout` field in the YAML configuration, after which restQL will break all running requests and exit.
 
-**Read timeout**: you can specify the maximum time taken to read the client request to the restQL API through the `web.server.readTimeout` field.
+**Read timeout**: you can specify the maximum time taken to read the client request to the restQL API through the `http.server.readTimeout` field.
 
 **Middlewares**: currently restQL support 3 built-in middlewares, setting any of the fields automatically enable the given middleware.
 
-- Request ID: this middleware generates a unique id for each request restQL API receives. The `web.server.middlewares.requestId.header` field define the header name use to return the generated id. The `web.server.middlewares.requestId.strategy` defines how the id will be generated and can be either `base64` or `uuid`.
-- Timeout: this middleware limits the maximum time any request can take. The `web.server.middlewares.timeout.duration` field aceppt a time duration value.
+- Request ID: this middleware generates a unique id for each request restQL API receives. The `http.server.middlewares.requestId.header` field define the header name use to return the generated id. The `http.server.middlewares.requestId.strategy` defines how the id will be generated and can be either `base64` or `uuid`.
+- Timeout: this middleware limits the maximum time any request can take. The `http.server.middlewares.timeout.duration` field aceppt a time duration value.
 - CORS: Cross-Origin Resource Sharing is a specification that enables truly open access across domain-boundaries.
   You can configure your own CORS headers either via the configuration file:
   ```yaml
-  web:
+  http:
     server:
       middlewares:
         cors:
@@ -69,12 +69,12 @@ You can use the `pprof` tool to investigate restQL performance. To enable it set
 
 RestQL primary feature is performing optimized HTTP calls, but since each environment has different characteristics like workload and latency, it is important that you tune the parameters for the internal HTTP client in order to achieve the best performance. You can set these parameters throught the configuration file.
 
-- `web.client.connectionTimeout`: limits the time taken to establish a TCP connection with a host.
-- `web.client.maxRequestTimeout`: although every the timeout for calling a resource can be defined by the client in the query you can set a upper limit to request time, for example, if you set it to `2s` even though a query specifies a timeout of `10s` restQL will drop the request when it reachs its maximum timeout. It accepts a duration string.
-- `web.client.maxConnectionsPerHost`: limits the size of the connection pool for each host.
-- `web.client.maxIdleConnections`: limits the size of the global idle connection pool.
-- `web.client.maxIdleConnectionsPerHost`: limits the size of the idle connection pool for each host.
-- `web.client.maxIdleConnectionDuration`: set the time a connection will be kept open in idle state, after it the connection will be closed. It accepts a duration string.
+- `http.client.connectionTimeout`: limits the time taken to establish a TCP connection with a host.
+- `http.client.maxRequestTimeout`: although every the timeout for calling a resource can be defined by the client in the query you can set a upper limit to request time, for example, if you set it to `2s` even though a query specifies a timeout of `10s` restQL will drop the request when it reachs its maximum timeout. It accepts a duration string.
+- `http.client.maxConnectionsPerHost`: limits the size of the connection pool for each host.
+- `http.client.maxIdleConnections`: limits the size of the global idle connection pool.
+- `http.client.maxIdleConnectionsPerHost`: limits the size of the idle connection pool for each host.
+- `http.client.maxIdleConnectionDuration`: set the time a connection will be kept open in idle state, after it the connection will be closed. It accepts a duration string.
 
 ## Caching
 

--- a/docs/restql/config.md
+++ b/docs/restql/config.md
@@ -52,10 +52,12 @@ You can use the `pprof` tool to investigate restQL performance. To enable it set
     server:
       middlewares:
         cors:
-          allowOrigin: ${allowed_custom_origin}
-          allowMethods: ${allowed_custom_methods}
-          allowHeaders: ${allowed_custom_headers}
-          exposeHeaders: ${allowed_custom_expose_headers}
+          allowOrigin: "example.com, hero.api"
+          allowMethods: "GET, POST"
+          allowHeaders: "X-TID, X-Custom"
+          allowCredentials: false
+          exposeHeaders: "X-TID"
+          maxAge: 10 # seconds, as per specification
   ```
   Or via environment variables:
   ```shell script
@@ -63,6 +65,8 @@ You can use the `pprof` tool to investigate restQL performance. To enable it set
   RESTQL_CORS_ALLOW_METHODS=${allowed_custom_methods}
   RESTQL_CORS_ALLOW_HEADERS=${allowed_custom_headers}
   RESTQL_CORS_EXPOSE_HEADERS=${allowed_custom_expose_headers}
+  RESTQL_CORS_ALLOW_CREDENTIALS=${allowed_credentials}
+  RESTQL_CORS_MAX_AGE=${allowed_max_age}
   ```
 
 ### Http Client

--- a/internal/platform/conf/conf.go
+++ b/internal/platform/conf/conf.go
@@ -23,10 +23,12 @@ type timeoutConf struct {
 }
 
 type corsConf struct {
-	AllowOrigin   string `yaml:"allowOrigin" env:"RESTQL_CORS_ALLOW_ORIGIN"`
-	AllowMethods  string `yaml:"allowMethods" env:"RESTQL_CORS_ALLOW_METHODS"`
-	AllowHeaders  string `yaml:"allowHeaders" env:"RESTQL_CORS_ALLOW_HEADERS"`
-	ExposeHeaders string `yaml:"exposeHeaders" env:"RESTQL_CORS_EXPOSE_HEADERS"`
+	AllowOrigin      string `yaml:"allowOrigin" env:"RESTQL_CORS_ALLOW_ORIGIN"`
+	AllowMethods     string `yaml:"allowMethods" env:"RESTQL_CORS_ALLOW_METHODS"`
+	AllowHeaders     string `yaml:"allowHeaders" env:"RESTQL_CORS_ALLOW_HEADERS"`
+	ExposeHeaders    string `yaml:"exposeHeaders" env:"RESTQL_CORS_EXPOSE_HEADERS"`
+	MaxAge           int    `yaml:"maxAge" env:"RESTQL_CORS_MAX_AGE"`
+	AllowCredentials bool   `yaml:"allowCredentials" env:"RESTQL_CORS_ALLOW_CREDENTIALS"`
 }
 
 type requestCancellationConf struct {

--- a/internal/platform/web/middleware/cors.go
+++ b/internal/platform/web/middleware/cors.go
@@ -1,198 +1,310 @@
 package middleware
 
 import (
+	"bytes"
 	"github.com/b2wdigital/restQL-golang/v4/pkg/restql"
+	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/valyala/fasthttp"
 )
 
-var (
-	accessControlAllowOriginHeaderName   = []byte("Access-Control-Allow-Origin")
-	accessControlAllowMethodsHeaderName  = []byte("Access-Control-Allow-Methods")
-	accessControlAllowHeadersHeaderName  = []byte("Access-Control-Allow-Headers")
-	accessControlExposeHeadersHeaderName = []byte("Access-Control-Expose-Headers")
-
-	accessControlRequestHeadersHeaderName = []byte("Access-Control-Request-Headers")
-	accessControlRequestMethodHeaderName  = []byte("Access-Control-Request-Method")
-	originHeaderName                      = []byte("Origin")
-)
-
-type option func(c *cors)
-
-func withAllowOrigins(allowedOrigins string) option {
-	return func(c *cors) {
-		origins := strings.Split(allowedOrigins, ",")
-		allowedOriginSet := make(map[string]struct{})
-
-		for _, o := range origins {
-			o := strings.TrimSpace(o)
-			if o == "*" {
-				c.allowedOriginsAll = true
-			}
-			allowedOriginSet[o] = struct{}{}
-		}
-
-		c.allowedOriginSet = allowedOriginSet
-	}
+// corsOptions is a configuration container to setup the CORS middleware.
+type corsOptions struct {
+	// AllowedOrigins is a comma separated list of origins a cross-domain request can be executed from.
+	// If the special "*" value is present in the list, all origins will be allowed.
+	// An origin may contain a wildcard (*) to replace 0 or more characters
+	// (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penalty.
+	// Only one wildcard can be used per origin.
+	// Default value is "*"
+	AllowedOrigins string
+	// AllowedMethods is a comma separated list of methods the client is allowed to use with
+	// cross-domain requests. Default value is simple methods (HEAD, GET and POST).
+	AllowedMethods string
+	// AllowedHeaders is a comma separated list of non simple headers the client is allowed to use with
+	// cross-domain requests.
+	// If the special "*" value is present in the list, all headers will be allowed.
+	// Default value is [] but "Origin" is always appended to the list.
+	AllowedHeaders string
+	// ExposedHeaders indicates which headers are safe to expose to the API of a CORS
+	// API specification.
+	ExposedHeaders string
+	// MaxAge indicates how long (in seconds) the results of a preflight request
+	// can be cached by the client.
+	MaxAge int
+	// AllowCredentials indicates whether the request can include user credentials like
+	// cookies, HTTP authentication or client side SSL certificates.
+	AllowCredentials bool
 }
 
-func withAllowHeaders(allowedHeaders string) option {
-	return func(c *cors) {
-		headers := strings.Split(allowedHeaders, ",")
-		allowedHeadersSet := make(map[string]struct{})
+// cors middleware
+type cors struct {
+	log                    restql.Logger
+	allowedOrigins         [][]byte
+	allowedWildcardOrigins []wildcard
+	allowedHeaders         []byte
+	allowedMethods         []byte
+	exposedHeaders         []byte
+	maxAge                 []byte
+	allowedOriginsAll      bool
+	allowedHeadersAll      bool
+	allowCredentials       bool
+}
+
+// newCors creates a new cors middleware with the provided options.
+func newCors(log restql.Logger, options corsOptions) *cors {
+	c := &cors{
+		allowCredentials: options.AllowCredentials,
+		log:              log,
+	}
+
+	parseOptions(c, options)
+
+	return c
+}
+
+func parseOptions(c *cors, options corsOptions) {
+	// Normalize options
+	// Note: for origins and methods matching, the spec requires a case-sensitive matching.
+	// As it may error prone, we chose to ignore the spec here.
+
+	// Allowed Origins
+	if options.AllowedOrigins == "" {
+		// Default is all origins
+		c.allowedOriginsAll = true
+	} else {
+		origins := strings.Split(options.AllowedOrigins, ",")
+		origins = convert(origins, strings.TrimSpace)
+
+		c.allowedOrigins = [][]byte{}
+		c.allowedWildcardOrigins = []wildcard{}
+		for _, origin := range origins {
+			if origin == "*" {
+				// If "*" is present in the list, turn the whole list into a match all
+				c.allowedOriginsAll = true
+				c.allowedOrigins = nil
+				c.allowedWildcardOrigins = nil
+				break
+			} else if i := strings.IndexByte(origin, '*'); i >= 0 {
+				// Split the origin in two: start and end string without the *
+				w := wildcard{prefix: []byte(origin[0:i]), suffix: []byte(origin[i+1:])}
+				c.allowedWildcardOrigins = append(c.allowedWildcardOrigins, w)
+			} else {
+				c.allowedOrigins = append(c.allowedOrigins, []byte(origin))
+			}
+		}
+	}
+
+	// Allowed Headers
+	var headers []string
+	if options.AllowedHeaders == "" {
+		// Use sensible defaults
+		headers = []string{"Origin", "Accept", "Content-Type", "X-Requested-With"}
+	} else {
+		// Origin is always appended as some browsers will always request for this header at preflight
+		headers = strings.Split(options.AllowedHeaders, ",")
+		headers = convert(headers, strings.TrimSpace)
+		headers = append(headers, "Origin")
+		headers = convert(headers, http.CanonicalHeaderKey)
 
 		for _, h := range headers {
-			h := strings.TrimSpace(h)
 			if h == "*" {
 				c.allowedHeadersAll = true
+				c.allowedHeaders = nil
+				break
 			}
-			allowedHeadersSet[h] = struct{}{}
 		}
+	}
+	if !c.allowedHeadersAll {
+		c.allowedHeaders = []byte(strings.Join(headers, ", "))
+	}
 
-		c.allowedHeadersSet = allowedHeadersSet
+	if options.ExposedHeaders != "" {
+		exposedHeaders := strings.Split(options.ExposedHeaders, ",")
+		exposedHeaders = convert(exposedHeaders, strings.TrimSpace)
+		exposedHeaders = convert(exposedHeaders, http.CanonicalHeaderKey)
+
+		c.exposedHeaders = []byte(strings.Join(exposedHeaders, ", "))
+	}
+
+	// Allowed Methods
+	var methods []string
+	if options.AllowedMethods == "" {
+		// Default is spec's "simple" methods
+		methods = []string{http.MethodGet, http.MethodPost, http.MethodHead}
+	} else {
+		methods = strings.Split(options.AllowedMethods, ",")
+		methods = convert(methods, strings.TrimSpace)
+		methods = convert(methods, strings.ToUpper)
+	}
+
+	c.allowedMethods = []byte(strings.Join(methods, ", "))
+
+	if options.MaxAge > 0 {
+		c.maxAge = []byte(strconv.Itoa(options.MaxAge))
 	}
 }
 
-func withAllowMethods(allowedMethods string) option {
-	return func(c *cors) {
-		methods := strings.Split(allowedMethods, ",")
-		allowedMethodsSet := make(map[string]struct{})
-
-		for _, m := range methods {
-			allowedMethodsSet[strings.TrimSpace(m)] = struct{}{}
-		}
-
-		c.allowedMethodsSet = allowedMethodsSet
-	}
-}
-
-func withExposedHeaders(exposedHeaders string) option {
-	return func(c *cors) {
-		c.exposedHeaders = exposedHeaders
-	}
-}
-
-type cors struct {
-	allowedOriginSet  map[string]struct{}
-	allowedOriginsAll bool
-	allowedHeadersSet map[string]struct{}
-	allowedHeadersAll bool
-	allowedMethodsSet map[string]struct{}
-	exposedHeaders    string
-	logger            restql.Logger
-}
-
-func newCors(log restql.Logger, options ...option) Middleware {
-	c := cors{logger: log}
-
-	for _, option := range options {
-		option(&c)
-	}
-
-	return &c
-}
-
+// Apply wraps a request handler with the CORS middleware.
 func (c *cors) Apply(h fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
-		if string(ctx.Method()) == fasthttp.MethodOptions {
+		method := string(ctx.Method())
+
+		if method == fasthttp.MethodOptions {
+			c.log.Debug("handling preflight request")
 			c.handlePreflight(ctx)
-			ctx.SetStatusCode(200)
+			// Preflight requests are standalone and should stop the chain as some other
+			// middleware may not handle OPTIONS requests correctly. One typical example
+			// is authentication middleware ; OPTIONS requests won't carry authentication
+			// headers (see rs/cors#1)
+			ctx.SetStatusCode(fasthttp.StatusOK)
 		} else {
-			c.handleActual(ctx)
+			c.log.Debug("handling actual request")
+			c.handleActualRequest(ctx)
 			h(ctx)
 		}
 	}
 }
 
+var (
+	// Response headers names
+	accessControlAllowOrigin      = []byte("Access-Control-Allow-Origin")
+	accessControlAllowMethods     = []byte("Access-Control-Allow-Methods")
+	accessControlAllowHeaders     = []byte("Access-Control-Allow-Headers")
+	accessControlExposeHeaders    = []byte("Access-Control-Expose-Headers")
+	accessControlAllowCredentials = []byte("Access-Control-Allow-Credentials")
+	accessControlMaxAge           = []byte("Access-Control-Max-Age")
+	vary                          = []byte("Vary")
+
+	// Vary header values
+	varyOrigin                      = []byte("Origin")
+	varyAccessControlRequestMethod  = []byte("Access-Control-Request-Method")
+	varyAccessControlRequestHeaders = []byte("Access-Control-Request-Headers")
+)
+
+// handlePreflight handles pre-flight CORS requests
 func (c *cors) handlePreflight(ctx *fasthttp.RequestCtx) {
-	originHeader := ctx.Request.Header.PeekBytes(originHeaderName)
-	if len(originHeader) == 0 || !c.isAllowedOrigin(originHeader) {
-		c.logger.Debug("origin is not allowed", "origin", originHeader)
+	headers := &ctx.Response.Header
+	origin := ctx.Request.Header.Peek("Origin")
+
+	// Always set Vary headers
+	// see https://github.com/rs/cors/issues/10,
+	//     https://github.com/rs/cors/commit/dbdca4d95feaa7511a46e6f1efb3b3aa505bc43f#commitcomment-12352001
+	headers.AddBytesKV(vary, varyOrigin)
+	headers.AddBytesKV(vary, varyAccessControlRequestMethod)
+	headers.AddBytesKV(vary, varyAccessControlRequestHeaders)
+
+	if len(origin) == 0 {
+		c.log.Debug("preflight request missing origin")
 		return
 	}
 
-	method := ctx.Request.Header.PeekBytes(accessControlRequestMethodHeaderName)
-	if !c.isAllowedMethod(method) {
-		c.logger.Debug("method is not allowed", "method", method)
-		return
-	}
-
-	headers, allowed := c.extractAndVerifyAccessControlRequestHeaders(ctx)
-	if !allowed {
-		c.logger.Debug("headers not allowed", "headers", headers)
-		return
-	}
-
-	if headers != "" {
-		ctx.Response.Header.SetBytesK(accessControlAllowHeadersHeaderName, headers)
-	}
-	ctx.Response.Header.SetBytesKV(accessControlAllowOriginHeaderName, originHeader)
-	ctx.Response.Header.SetBytesKV(accessControlAllowMethodsHeaderName, method)
-}
-
-func (c *cors) handleActual(ctx *fasthttp.RequestCtx) {
-	originHeader := ctx.Request.Header.PeekBytes(originHeaderName)
-	if len(originHeader) == 0 || !c.isAllowedOrigin(originHeader) {
-		c.logger.Debug("origin is not allowed", "origin", originHeader)
-		return
-	}
-
-	ctx.Response.Header.SetBytesKV(accessControlAllowOriginHeaderName, originHeader)
-	if c.exposedHeaders != "" {
-		ctx.Response.Header.SetBytesK(accessControlExposeHeadersHeaderName, c.exposedHeaders)
-	}
-}
-
-func (c *cors) isAllowedOrigin(originHeader []byte) bool {
 	if c.allowedOriginsAll {
-		return true
-	}
-
-	origin := string(originHeader)
-	_, found := c.allowedOriginSet[origin]
-
-	return found
-}
-
-func (c *cors) isAllowedMethod(methodHeader []byte) bool {
-	if len(c.allowedMethodsSet) == 0 {
-		return false
-	}
-
-	method := string(methodHeader)
-
-	if method == "OPTIONS" {
-		return true
-	}
-
-	_, found := c.allowedMethodsSet[method]
-	return found
-}
-
-func (c *cors) areHeadersAllowed(headers []string) bool {
-	if c.allowedHeadersAll || len(headers) == 0 {
-		return true
-	}
-
-	for _, header := range headers {
-		_, found := c.allowedHeadersSet[header]
-
-		if !found {
-			return false
+		headers.SetBytesK(accessControlAllowOrigin, "*")
+	} else {
+		if c.isOriginAllowed(origin) {
+			headers.SetBytesKV(accessControlAllowOrigin, origin)
 		}
 	}
 
-	return true
-}
+	headers.SetBytesKV(accessControlAllowMethods, c.allowedMethods)
 
-func (c *cors) extractAndVerifyAccessControlRequestHeaders(ctx *fasthttp.RequestCtx) (string, bool) {
-	if len(ctx.Request.Header.PeekBytes(accessControlRequestHeadersHeaderName)) == 0 {
-		return "", true
+	if c.allowedHeadersAll {
+		rh := ctx.Request.Header.Peek("Access-Control-Request-Headers")
+		headers.SetBytesKV(accessControlAllowHeaders, rh)
+	} else {
+		headers.SetBytesKV(accessControlAllowHeaders, c.allowedHeaders)
 	}
 
-	accessControlRequestHeaders := string(ctx.Request.Header.PeekBytes(accessControlRequestHeadersHeaderName))
-	headers := strings.Split(accessControlRequestHeaders, ",")
+	if c.allowCredentials {
+		headers.SetBytesK(accessControlAllowCredentials, "true")
+	}
+	if c.maxAge != nil {
+		headers.SetBytesKV(accessControlMaxAge, c.maxAge)
+	}
+}
 
-	return accessControlRequestHeaders, c.areHeadersAllowed(headers)
+// handleActualRequest handles simple cross-origin requests, actual request or redirects
+func (c *cors) handleActualRequest(ctx *fasthttp.RequestCtx) {
+	headers := &ctx.Response.Header
+	origin := ctx.Request.Header.Peek("Origin")
+
+	// Always set Vary, see https://github.com/rs/cors/issues/10
+	headers.AddBytesKV(vary, varyOrigin)
+	if len(origin) == 0 {
+		c.log.Debug("actual request missing origin")
+		return
+	}
+
+	if c.allowedOriginsAll {
+		headers.SetBytesK(accessControlAllowOrigin, "*")
+	} else {
+		if c.isOriginAllowed(origin) {
+			headers.SetBytesKV(accessControlAllowOrigin, origin)
+		} else {
+			c.log.Debug("origin not allowed", "origin", string(origin))
+		}
+	}
+	if len(c.exposedHeaders) > 0 {
+		headers.SetBytesKV(accessControlExposeHeaders, c.exposedHeaders)
+	}
+	if c.allowCredentials {
+		headers.SetBytesK(accessControlAllowCredentials, "true")
+	}
+}
+
+// isOriginAllowed checks if a given origin is allowed to perform cross-domain requests
+// on the endpoint
+func (c *cors) isOriginAllowed(origin []byte) bool {
+	if c.allowedOriginsAll {
+		return true
+	}
+	for _, o := range c.allowedOrigins {
+		if bytes.EqualFold(o, origin) {
+			return true
+		}
+	}
+
+	for _, w := range c.allowedWildcardOrigins {
+		if w.match(origin) {
+			return true
+		}
+	}
+
+	return false
+}
+
+type converter func(string) string
+
+// convert converts a list of string using the passed converter function
+func convert(s []string, c converter) []string {
+	out := make([]string, len(s))
+	for i, si := range s {
+		out[i] = c(si)
+	}
+	return out
+}
+
+type wildcard struct {
+	prefix []byte
+	suffix []byte
+}
+
+func (w wildcard) match(s []byte) bool {
+	if len(s) < len(w.prefix)+len(w.suffix) {
+		return false
+	}
+
+	sp := s[:len(w.prefix)]
+	if !bytes.EqualFold(sp, w.prefix) {
+		return false
+	}
+
+	ss := s[len(s)-len(w.suffix):]
+	if !bytes.EqualFold(ss, w.suffix) {
+		return false
+	}
+
+	return true
 }

--- a/internal/platform/web/middleware/cors_test.go
+++ b/internal/platform/web/middleware/cors_test.go
@@ -1,0 +1,386 @@
+package middleware
+
+import (
+	"github.com/b2wdigital/restQL-golang/v4/test"
+	"strings"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+)
+
+var testHandler = fasthttp.RequestHandler(func(ctx *fasthttp.RequestCtx) {
+	ctx.SetBodyString("bar")
+})
+
+var allHeaders = []string{
+	"Vary",
+	"Access-Control-Allow-Origin",
+	"Access-Control-Allow-Methods",
+	"Access-Control-Allow-Headers",
+	"Access-Control-Allow-Credentials",
+	"Access-Control-Max-Age",
+	"Access-Control-Expose-Headers",
+}
+
+func assertHeaders(t *testing.T, resHeaders *fasthttp.ResponseHeader, expHeaders map[string]string) {
+	headers := make(map[string][]string, resHeaders.Len())
+	resHeaders.VisitAll(func(key []byte, value []byte) {
+		if arr, found := headers[string(key)]; found {
+			headers[string(key)] = append(arr, string(value))
+		} else {
+			headers[string(key)] = []string{string(value)}
+		}
+	})
+
+	for _, name := range allHeaders {
+		got := strings.Join(headers[name], ", ")
+		want := expHeaders[name]
+		if got != want {
+			t.Errorf("Response header %q = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestSpec(t *testing.T) {
+	cases := []struct {
+		name       string
+		options    corsOptions
+		method     string
+		reqHeaders map[string]string
+		resHeaders map[string]string
+	}{
+		{
+			"NoConfig",
+			corsOptions{
+				// Intentionally left blank.
+			},
+			"GET",
+			map[string]string{},
+			map[string]string{
+				"Vary": "Origin",
+			},
+		},
+		{
+			"MatchAllOrigin",
+			corsOptions{
+				AllowedOrigins: "*",
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary":                        "Origin",
+				"Access-Control-Allow-Origin": "*",
+			},
+		},
+		{
+			"MatchAllOriginWithCredentials",
+			corsOptions{
+				AllowedOrigins:   "*",
+				AllowCredentials: true,
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary":                             "Origin",
+				"Access-Control-Allow-Origin":      "*",
+				"Access-Control-Allow-Credentials": "true",
+			},
+		},
+		{
+			"AllowedOrigin",
+			corsOptions{
+				AllowedOrigins: "http://hero.com, http://foobar.com",
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary":                        "Origin",
+				"Access-Control-Allow-Origin": "http://foobar.com",
+			},
+		},
+		{
+			"WildcardOrigin",
+			corsOptions{
+				AllowedOrigins: "http://hero.com, http://*.bar.com",
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foo.bar.com",
+			},
+			map[string]string{
+				"Vary":                        "Origin",
+				"Access-Control-Allow-Origin": "http://foo.bar.com",
+			},
+		},
+		{
+			"DisallowedOrigin",
+			corsOptions{
+				AllowedOrigins: "http://hero.com, http://foobar.com",
+				ExposedHeaders: "X-Header-1, x-Header-2",
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://barbaz.com",
+			},
+			map[string]string{
+				"Vary":                          "Origin",
+				"Access-Control-Expose-Headers": "X-Header-1, X-Header-2",
+			},
+		},
+		{
+			"DisallowedWildcardOrigin",
+			corsOptions{
+				AllowedOrigins: "http://hero.com, http://*.bar.com",
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foo.baz.com",
+			},
+			map[string]string{
+				"Vary": "Origin",
+			},
+		},
+		{
+			"PreflightDisallowedOrigin",
+			corsOptions{
+				AllowedOrigins: "http://hero.com, http://foobar.com",
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin": "http://barbaz.com",
+			},
+			map[string]string{
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Headers": "Origin, Accept, Content-Type, X-Requested-With",
+				"Access-Control-Allow-Methods": "GET, POST, HEAD",
+			},
+		},
+		{
+			"PreflightDisallowedWildcardOrigin",
+			corsOptions{
+				AllowedOrigins: "http://hero.com, http://*.bar.com",
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin": "http://foo.baz.com",
+			},
+			map[string]string{
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Headers": "Origin, Accept, Content-Type, X-Requested-With",
+				"Access-Control-Allow-Methods": "GET, POST, HEAD",
+			},
+		},
+		{
+			"MaxAge",
+			corsOptions{
+				AllowedOrigins: "http://example.com/",
+				AllowedMethods: "GET",
+				MaxAge:         10,
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                        "http://example.com/",
+				"Access-Control-Request-Method": "GET",
+			},
+			map[string]string{
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://example.com/",
+				"Access-Control-Allow-Methods": "GET",
+				"Access-Control-Max-Age":       "10",
+				"Access-Control-Allow-Headers": "Origin, Accept, Content-Type, X-Requested-With",
+			},
+		},
+		{
+			"AllowedMethod",
+			corsOptions{
+				AllowedOrigins: "http://foobar.com",
+				AllowedMethods: "PUT, delete",
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                        "http://foobar.com",
+				"Access-Control-Request-Method": "PUT",
+			},
+			map[string]string{
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "PUT, DELETE",
+				"Access-Control-Allow-Headers": "Origin, Accept, Content-Type, X-Requested-With",
+			},
+		},
+		{
+			"AllowedHeaders",
+			corsOptions{
+				AllowedOrigins: "http://foobar.com",
+				AllowedHeaders: "X-Header-1, x-header-2",
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "X-Header-2, X-HEADER-1",
+			},
+			map[string]string{
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "GET, POST, HEAD",
+				"Access-Control-Allow-Headers": "X-Header-1, X-Header-2, Origin",
+			},
+		},
+		{
+			"DefaultAllowedHeaders",
+			corsOptions{
+				AllowedOrigins: "http://foobar.com",
+				AllowedHeaders: "",
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "X-Requested-With",
+			},
+			map[string]string{
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "GET, POST, HEAD",
+				"Access-Control-Allow-Headers": "Origin, Accept, Content-Type, X-Requested-With",
+			},
+		},
+		{
+			"AllowedAllHeaders",
+			corsOptions{
+				AllowedOrigins: "http://foobar.com",
+				AllowedHeaders: "*",
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "X-Header-2, X-HEADER-1",
+			},
+			map[string]string{
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "GET, POST, HEAD",
+				"Access-Control-Allow-Headers": "X-Header-2, X-HEADER-1",
+			},
+		},
+		{
+			"OriginHeader",
+			corsOptions{
+				AllowedOrigins: "http://foobar.com",
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "origin",
+			},
+			map[string]string{
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "GET, POST, HEAD",
+				"Access-Control-Allow-Headers": "Origin, Accept, Content-Type, X-Requested-With",
+			},
+		},
+		{
+			"ExposedHeader",
+			corsOptions{
+				AllowedOrigins: "http://foobar.com",
+				ExposedHeaders: "X-Header-1, x-header-2",
+			},
+			"GET",
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary":                          "Origin",
+				"Access-Control-Allow-Origin":   "http://foobar.com",
+				"Access-Control-Expose-Headers": "X-Header-1, X-Header-2",
+			},
+		},
+		{
+			"AllowedCredentials",
+			corsOptions{
+				AllowedOrigins:   "http://foobar.com",
+				AllowCredentials: true,
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                        "http://foobar.com",
+				"Access-Control-Request-Method": "GET",
+			},
+			map[string]string{
+				"Vary":                             "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":      "http://foobar.com",
+				"Access-Control-Allow-Methods":     "GET, POST, HEAD",
+				"Access-Control-Allow-Credentials": "true",
+				"Access-Control-Allow-Headers":     "Origin, Accept, Content-Type, X-Requested-With",
+			},
+		},
+	}
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			s := newCors(test.NoOpLogger, tc.options)
+
+			ctx := fasthttp.RequestCtx{}
+			ctx.Request.Header.SetMethod(tc.method)
+			ctx.Request.SetRequestURI("http://example.com/foo")
+			for name, value := range tc.reqHeaders {
+				ctx.Request.Header.Add(name, value)
+			}
+
+			s.Apply(testHandler)(&ctx)
+			assertHeaders(t, &ctx.Response.Header, tc.resHeaders)
+		})
+	}
+}
+
+func TestHandlePreflightEmptyOriginAbortion(t *testing.T) {
+	s := newCors(test.NoOpLogger, corsOptions{
+		AllowedOrigins: "http://foo.com",
+	})
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("OPTIONS")
+	ctx.Request.SetRequestURI("http://example.com/foo")
+
+	s.handlePreflight(&ctx)
+
+	assertHeaders(t, &ctx.Response.Header, map[string]string{
+		"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+	})
+}
+
+func TestHandleActualRequestEmptyOriginAbortion(t *testing.T) {
+	s := newCors(test.NoOpLogger, corsOptions{
+		AllowedOrigins: "http://foo.com",
+	})
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("http://example.com/foo")
+
+	s.handleActualRequest(&ctx)
+
+	assertHeaders(t, &ctx.Response.Header, map[string]string{
+		"Vary": "Origin",
+	})
+}
+
+// Utils testing
+
+func TestConvert(t *testing.T) {
+	s := convert([]string{"A", "b", "C"}, strings.ToLower)
+	e := []string{"a", "b", "c"}
+	if s[0] != e[0] || s[1] != e[1] || s[2] != e[2] {
+		t.Errorf("%v != %v", s, e)
+	}
+}

--- a/internal/platform/web/middleware/middleware.go
+++ b/internal/platform/web/middleware/middleware.go
@@ -72,12 +72,14 @@ func (d *Decorator) fetchEnabled() []Middleware {
 	}
 
 	if mwCfg.Cors != nil {
-		cors := newCors(d.log,
-			withAllowOrigins(mwCfg.Cors.AllowOrigin),
-			withAllowHeaders(mwCfg.Cors.AllowHeaders),
-			withAllowMethods(mwCfg.Cors.AllowMethods),
-			withExposedHeaders(mwCfg.Cors.ExposeHeaders),
-		)
+		cors := newCors(d.log, corsOptions{
+			AllowedOrigins:   mwCfg.Cors.AllowOrigin,
+			AllowedMethods:   mwCfg.Cors.AllowMethods,
+			AllowedHeaders:   mwCfg.Cors.AllowHeaders,
+			ExposedHeaders:   mwCfg.Cors.ExposeHeaders,
+			MaxAge:           mwCfg.Cors.MaxAge,
+			AllowCredentials: mwCfg.Cors.AllowCredentials,
+		})
 		mws = append(mws, cors)
 	}
 


### PR DESCRIPTION
This PR extends the CORS middleware to better cover the specification. The implementation presented here is highly inspired by the [rs/cors](https://github.com/rs/cors) package.

However, some modifications here made for restQL, most notably that the request handling implementation on [rs/cors](https://github.com/rs/cors/blob/8b4a00bd362b5f326bff479ebe0af7862868225e/cors.go#L281) abort the execution when the origin, method, or request headers to be issued by the client are not allowed and we choose to not abort and return the appropriate headers if possible.

This decision is based on the [CORS spec]() about how the `Access-Control-Allow-Methods` response header is handled, pointing that if it's not present, then the actual request method will be automatically authorized. Hence, aborting the CORS logic on the server because a method is not allowed cause it to be authorized. This is further reinforced by the lib authors [here](https://github.com/rs/cors/issues/54#issuecomment-384080984). 

We choose to return all possible header, not only the ones related to methods because as pointed in this [issue](https://github.com/whatwg/fetch/issues/172) on the CORS spec repository, the enforcement point in on the client and the restQL as a server participating in the CORS protocol defer any blocking to its client by providing the maximum information possible about the authorized operations.


