### PR TITLE
Add enable flag to middlewares and remove mappings field

### DIFF
--- a/docs/restql/resource-mappings.md
+++ b/docs/restql/resource-mappings.md
@@ -2,26 +2,27 @@
 
 RestQL provides three ways to map resources
 
-1. Enviroment variables
+1. Environment variables
 2. Configuration File
 3. Database
 
 ### Environment variables
 
-RestQL will detect that an environment variable is a mapping if it starts with `RESTQL_MAPPING_` followed by the resource name (that will be lowercased) and the value should be the target url, for example, `RESTQL_MAPPING_HERO=http://hero.api/` will create a mapping with name `hero` and target `http://hero.api/`.
+RestQL will detect that an environment variable is a mapping if it starts with `RESTQL_MAPPING_` followed by the tenant (that will be used as is) name, another underline and then resource name (that will be lowercased) and the value should be the target url, for example, `RESTQL_MAPPING_MYTENANT_HERO=http://hero.api/` will create a mapping with name `hero` and target `http://hero.api/`.
 
-These mappings will be available for any tenant, and it overwrites any mapping with the same name present in database or configuration file.
+These mappings overwrite any mapping with the same name present in database or configuration file.
 
 ### Configuration file
 
 You can define mappings in the configuration file like:
 
 ```yaml
-mappings:
-  hero: http://hero.api/
+tenants:
+  my-tenant:
+    hero: http://hero.api/
 ```
 
-These mappings will be available for any tenant, but can be overwritten by a mapping with the same name present in the database or the environment.
+These mappings can be overwritten by a mapping with the same name present in the database or the environment.
 
 ### Database
 

--- a/internal/platform/conf/conf.go
+++ b/internal/platform/conf/conf.go
@@ -14,15 +14,18 @@ import (
 const configFileName = "restql.yml"
 
 type requestIDConf struct {
+	Enable   bool   `yaml:"enable"`
 	Header   string `yaml:"header"`
 	Strategy string `yaml:"strategy"`
 }
 
 type timeoutConf struct {
+	Enable   bool   `yaml:"enable"`
 	Duration string `yaml:"duration"`
 }
 
 type corsConf struct {
+	Enable           bool   `yaml:"enable" env:"RESTQL_CORS_ENABLED"`
 	AllowOrigin      string `yaml:"allowOrigin" env:"RESTQL_CORS_ALLOW_ORIGIN"`
 	AllowMethods     string `yaml:"allowMethods" env:"RESTQL_CORS_ALLOW_METHODS"`
 	AllowHeaders     string `yaml:"allowHeaders" env:"RESTQL_CORS_ALLOW_HEADERS"`
@@ -32,7 +35,7 @@ type corsConf struct {
 }
 
 type requestCancellationConf struct {
-	Enabled       bool          `yaml:"enabled"`
+	Enable        bool          `yaml:"enable"`
 	WatchInterval time.Duration `yaml:"watchInterval"`
 }
 
@@ -59,10 +62,10 @@ type Config struct {
 			IdleTimeout             time.Duration `yaml:"idleTimeout"`
 
 			Middlewares struct {
-				RequestID           *requestIDConf           `yaml:"requestId"`
-				Timeout             *timeoutConf             `yaml:"timeout"`
-				Cors                *corsConf                `yaml:"cors"`
-				RequestCancellation *requestCancellationConf `yaml:"requestCancellation"`
+				RequestID           requestIDConf           `yaml:"requestId"`
+				Timeout             timeoutConf             `yaml:"timeout"`
+				Cors                corsConf                `yaml:"cors"`
+				RequestCancellation requestCancellationConf `yaml:"requestCancellation"`
 			} `yaml:"middlewares"`
 		} `yaml:"server"`
 
@@ -105,8 +108,6 @@ type Config struct {
 	} `yaml:"plugins"`
 
 	Tenant string `env:"RESTQL_TENANT"`
-
-	Mappings map[string]string `yaml:"mappings"`
 
 	TenantMappings map[string]map[string]string `yaml:"tenants"`
 

--- a/internal/platform/persistence/mappings.go
+++ b/internal/platform/persistence/mappings.go
@@ -184,7 +184,7 @@ func getMappingsFromEnv(log restql.Logger, envSource domain.EnvSource) map[strin
 	for key, value := range env {
 		matches := envMappingWithTenantRegex.FindAllStringSubmatch(key, -1)
 		if len(matches) > 0 && len(matches[0]) >= 3 {
-			tenant := strings.ToLower(matches[0][1])
+			tenant := matches[0][1]
 			resource := strings.ToLower(matches[0][2])
 			mapping, err := restql.NewMapping(resource, value)
 			if err != nil {

--- a/internal/platform/persistence/mappings_test.go
+++ b/internal/platform/persistence/mappings_test.go
@@ -24,7 +24,7 @@ func TestMappingsReader_Env(t *testing.T) {
 	}
 	db := stubDatabase{}
 
-	reader := NewMappingReader(noOpLogger, envSource, map[string]string{}, map[string]map[string]string{}, db)
+	reader := NewMappingReader(noOpLogger, envSource, map[string]map[string]string{}, db)
 
 	heroMapping, err := restql.NewMapping("hero", "http://hero.api/")
 	test.VerifyError(t, err)
@@ -60,7 +60,7 @@ func TestMappingsReader_Local(t *testing.T) {
 	}
 	db := stubDatabase{}
 
-	reader := NewMappingReader(noOpLogger, envSource, local, localByTenant, db)
+	reader := NewMappingReader(noOpLogger, envSource, localByTenant, db)
 
 	heroMapping, err := restql.NewMapping("hero", "http://hero.api/")
 	test.VerifyError(t, err)
@@ -95,7 +95,7 @@ func TestMappingsReader_Database(t *testing.T) {
 
 	db := stubDatabase{findMappingsForTenant: []restql.Mapping{heroMapping, sidekickMapping}}
 
-	reader := NewMappingReader(noOpLogger, envSource, local, nil, db)
+	reader := NewMappingReader(noOpLogger, envSource, nil, db)
 
 	expected := map[string]restql.Mapping{
 		"hero":     heroMapping,
@@ -132,7 +132,7 @@ func TestMappingsReader_ShouldOverwriteMappings(t *testing.T) {
 		},
 	}
 
-	reader := NewMappingReader(noOpLogger, envSource, local, nil, db)
+	reader := NewMappingReader(noOpLogger, envSource, nil, db)
 
 	expected := map[string]restql.Mapping{
 		"hero":     heroMapping,

--- a/internal/platform/web/middleware/middleware.go
+++ b/internal/platform/web/middleware/middleware.go
@@ -31,7 +31,7 @@ type Decorator struct {
 
 // NewDecorator creates a middleware Decorator
 func NewDecorator(log restql.Logger, cfg *conf.Config, pm plugins.Lifecycle) *Decorator {
-	cmEnabled := cfg.HTTP.Server.Middlewares.RequestCancellation.Enabled
+	cmEnabled := cfg.HTTP.Server.Middlewares.RequestCancellation.Enable
 	cmWatchingInterval := cfg.HTTP.Server.Middlewares.RequestCancellation.WatchInterval
 
 	return &Decorator{
@@ -61,15 +61,15 @@ func (d *Decorator) fetchEnabled() []Middleware {
 	mws := []Middleware{newRecoverer(d.log), newNativeContext(d.cm), newTransaction(d.pm)}
 
 	mwCfg := d.cfg.HTTP.Server.Middlewares
-	if mwCfg.Timeout != nil {
+	if mwCfg.Timeout.Enable {
 		mws = append(mws, newTimeout(mwCfg.Timeout.Duration, d.log))
 	}
 
-	if mwCfg.RequestID != nil {
+	if mwCfg.RequestID.Enable {
 		mws = append(mws, newRequestID(mwCfg.RequestID.Header, mwCfg.RequestID.Strategy, d.log))
 	}
 
-	if mwCfg.Cors != nil {
+	if mwCfg.Cors.Enable {
 		cors := newCors(d.log, corsOptions{
 			AllowedOrigins:   mwCfg.Cors.AllowOrigin,
 			AllowedMethods:   mwCfg.Cors.AllowMethods,

--- a/internal/platform/web/routes.go
+++ b/internal/platform/web/routes.go
@@ -43,7 +43,7 @@ func API(log restql.Logger, cfg *conf.Config) (fasthttp.RequestHandler, error) {
 	executor := runner.NewExecutor(log, client, cfg.HTTP.QueryResourceTimeout, cfg.HTTP.ForwardPrefix)
 	r := runner.NewRunner(log, executor, cfg.HTTP.GlobalQueryTimeout)
 
-	mappingReader := persistence.NewMappingReader(log, cfg.Env, cfg.Mappings, cfg.TenantMappings, db)
+	mappingReader := persistence.NewMappingReader(log, cfg.Env, cfg.TenantMappings, db)
 	tenantCache := cache.New(log, cfg.Cache.Mappings.MaxSize,
 		cache.TenantCacheLoader(mappingReader),
 		cache.WithExpiration(cfg.Cache.Mappings.Expiration),
@@ -69,7 +69,7 @@ func API(log restql.Logger, cfg *conf.Config) (fasthttp.RequestHandler, error) {
 
 	if cfg.HTTP.Server.Admin.Enable {
 		log.Info("administration api enabled")
-		mw := persistence.NewMappingWriter(log, cfg.Env, cfg.Mappings, cfg.TenantMappings, db)
+		mw := persistence.NewMappingWriter(log, cfg.Env, cfg.TenantMappings, db)
 		qw := persistence.NewQueryWriter(log, cfg.Queries, db)
 
 		adm := newAdmin(mappingReader, mw, queryReader, qw, cfg.HTTP.Server.Admin.AuthorizationCode)

--- a/test/e2e/restql.yml
+++ b/test/e2e/restql.yml
@@ -11,12 +11,13 @@ logging:
   level: debug
   format: pretty
 
-mappings:
-  planets: http://localhost:65000/api/planets/:id
-  people: http://localhost:65000/api/people/:id
-  starships: http://localhost:65000/api/starships?:id&:name
-  planets-prod: https://swapi.dev/api/planets/:id
-  people-prod: https://swapi.dev/api//people/:id
+tenants:
+  DEFAULT:
+    planets: http://localhost:65000/api/planets/:id
+    people: http://localhost:65000/api/people/:id
+    starships: http://localhost:65000/api/starships?:id&:name
+    planets-prod: https://swapi.dev/api/planets/:id
+    people-prod: https://swapi.dev/api//people/:id
 
 queries:
   test:


### PR DESCRIPTION
**This PR breaks the contract of the YAML configuration file.**

It introduces an `enable` flag to all middlewares. This fix the CORS configuration that, although could be customized via environment variables, could not be activated through env vars. Now, the `RESTQL_CORS_ENABLED` overwrites the `enable` flag on the YAML config file for the CORS middleware. In order to prevent this problem with other middlewares we turn this contract the standard and added the `enable` flag to all of them.

Since this will lead to a major release, this PR also removes the `mappings` field from the configuration file, which allowed for resource mappings without a binding to a tenant. 

Since version v4.4.0 restQL provides the `tenants` field on its configuration to set tenant binding static resource mappings.