### PR TITLE
Filtert unresolved values at the right place

### DIFF
--- a/internal/runner/request.go
+++ b/internal/runner/request.go
@@ -140,11 +140,39 @@ func makeQueryParams(forwardPrefix string, statement domain.Statement, mapping r
 			if mapping.IsPathParam(key) {
 				continue
 			}
+
+			if !isPrimitiveValue(value) {
+				continue
+			}
+
 			queryArgs[key] = value
 		}
 	}
 
 	return queryArgs
+}
+
+func isPrimitiveValue(value interface{}) bool {
+	if value == nil {
+		return false
+	}
+
+	switch value.(type) {
+	case string:
+		return true
+	case bool:
+		return true
+	case int:
+		return true
+	case float64:
+		return true
+	case map[string]interface{}:
+		return true
+	case []interface{}:
+		return true
+	default:
+		return false
+	}
 }
 
 func getForwardParams(forwardPrefix string, queryCtx restql.QueryContext) map[string]interface{} {

--- a/internal/runner/resquest_test.go
+++ b/internal/runner/resquest_test.go
@@ -110,6 +110,12 @@ func TestMakeRequest(t *testing.T) {
 			restql.QueryContext{Mappings: map[string]restql.Mapping{"hero": mapping(t, "http://hero.io/api")}, Input: restql.QueryInput{Headers: map[string]string{"Accept": "*/*"}}},
 			restql.HTTPRequest{Method: http.MethodGet, Schema: "http", Host: "hero.io", Path: "/api", Query: map[string]interface{}{}, Headers: map[string]string{"X-Tid": "1234567890", "Content-Type": "application/json", "Accept": "application/json"}},
 		},
+		{
+			"should make request with url and query params from statement, filtering non-primitive ones",
+			domain.Statement{Method: domain.FromMethod, Resource: "hero", With: domain.Params{Values: map[string]interface{}{"id": "123456", "name": domain.Chain{"failed-resource", "name"}}}},
+			restql.QueryContext{Mappings: map[string]restql.Mapping{"hero": mapping(t, "http://hero.io/api")}},
+			restql.HTTPRequest{Method: http.MethodGet, Schema: "http", Host: "hero.io", Path: "/api", Query: map[string]interface{}{"id": "123456"}, Headers: map[string]string{"Content-Type": "application/json"}},
+		},
 	}
 
 	forwardPrefix := "c_"


### PR DESCRIPTION
This PR closes #34.

It filters non primitive values when constructing an `HTTPRequest`, which will be latter used by the HTTP Client and the Lifecycle manager.

Since the HTTP Client had a logic to parse the values into strings it avoided the unresolved value to be really sent to the upstream API. Hoewever, it still appeared on the debug section on the query response and, pottencially, on the reported request send to the Lifecycle hook.