### PR TITLE
Implement concurrency limiters

### DIFF
--- a/internal/eval/evaluator.go
+++ b/internal/eval/evaluator.go
@@ -122,7 +122,7 @@ func (e Evaluator) evaluateQuery(ctx context.Context, queryTxt string, queryOpts
 		return nil, err
 	}
 
-	resources = ApplyAggregators(nil, query, resources)
+	resources = ApplyAggregators(log, query, resources)
 
 	e.lifecycle.AfterQuery(queryCtx, queryTxt, resources)
 

--- a/internal/platform/conf/conf.go
+++ b/internal/platform/conf/conf.go
@@ -43,8 +43,11 @@ type requestCancellationConf struct {
 type Config struct {
 	HTTP struct {
 		ForwardPrefix        string        `yaml:"forwardPrefix" env:"RESTQL_FORWARD_PREFIX"`
-		GlobalQueryTimeout   time.Duration `env:"RESTQL_QUERY_GLOBAL_TIMEOUT" envDefault:"30s"`
 		QueryResourceTimeout time.Duration `env:"RESTQL_QUERY_RESOURCE_TIMEOUT" envDefault:"5s"`
+
+		GlobalQueryTimeout      time.Duration `env:"RESTQL_QUERY_GLOBAL_TIMEOUT" envDefault:"30s"`
+		MaxConcurrentQueries    int           `yaml:"maxConcurrentQueries" env:"RESTQL_MAX_CONCURRENT_QUERIES"`
+		MaxConcurrentGoroutines int           `yaml:"maxConcurrentGoroutines" env:"RESTQL_MAX_CONCURRENT_GOROUTINES"`
 
 		Server struct {
 			APIAddr         string `env:"RESTQL_PORT,required"`

--- a/internal/platform/conf/conf.go
+++ b/internal/platform/conf/conf.go
@@ -45,9 +45,7 @@ type Config struct {
 		ForwardPrefix        string        `yaml:"forwardPrefix" env:"RESTQL_FORWARD_PREFIX"`
 		QueryResourceTimeout time.Duration `env:"RESTQL_QUERY_RESOURCE_TIMEOUT" envDefault:"5s"`
 
-		GlobalQueryTimeout      time.Duration `env:"RESTQL_QUERY_GLOBAL_TIMEOUT" envDefault:"30s"`
-		MaxConcurrentQueries    int           `yaml:"maxConcurrentQueries" env:"RESTQL_MAX_CONCURRENT_QUERIES"`
-		MaxConcurrentGoroutines int           `yaml:"maxConcurrentGoroutines" env:"RESTQL_MAX_CONCURRENT_GOROUTINES"`
+		GlobalQueryTimeout time.Duration `env:"RESTQL_QUERY_GLOBAL_TIMEOUT" envDefault:"30s"`
 
 		Server struct {
 			APIAddr         string `env:"RESTQL_PORT,required"`
@@ -73,6 +71,9 @@ type Config struct {
 		} `yaml:"server"`
 
 		Client struct {
+			MaxConcurrentQueries    int `yaml:"maxConcurrentQueries" env:"RESTQL_MAX_CONCURRENT_QUERIES"`
+			MaxConcurrentGoroutines int `yaml:"maxConcurrentGoroutines" env:"RESTQL_MAX_CONCURRENT_GOROUTINES"`
+
 			DnsRefreshInterval  time.Duration `yaml:"dnsRefreshInterval"`
 			ConnTimeout         time.Duration `yaml:"connectionTimeout"`
 			MaxRequestTimeout   time.Duration `yaml:"maxRequestTimeout"`

--- a/internal/platform/web/response.go
+++ b/internal/platform/web/response.go
@@ -8,8 +8,8 @@ import (
 	"github.com/b2wdigital/restQL-golang/v5/internal/eval"
 	"github.com/b2wdigital/restQL-golang/v5/internal/parser"
 	"github.com/b2wdigital/restQL-golang/v5/internal/platform/persistence"
+	"github.com/b2wdigital/restQL-golang/v5/internal/runner"
 	"github.com/b2wdigital/restQL-golang/v5/pkg/restql"
-	"net/http"
 	"strconv"
 
 	"github.com/valyala/fasthttp"
@@ -26,13 +26,15 @@ var errToStatusCode = map[error]int{
 	eval.ErrParser:                              fasthttp.StatusInternalServerError,
 	eval.ErrTimeout:                             fasthttp.StatusRequestTimeout,
 	eval.ErrMapping:                             fasthttp.StatusInternalServerError,
+	runner.ErrMaxQueryDenied:                    fasthttp.StatusInsufficientStorage,
+	runner.ErrMaxGoroutineDenied:                fasthttp.StatusInsufficientStorage,
 	parser.ErrInvalidQuery:                      fasthttp.StatusUnprocessableEntity,
 	persistence.ErrSetResourceMappingNotAllowed: fasthttp.StatusUnauthorized,
 	persistence.ErrCreateRevisionNotAllowed:     fasthttp.StatusUnauthorized,
 	errPathParamNotFound:                        fasthttp.StatusUnprocessableEntity,
 	errInvalidTenant:                            fasthttp.StatusBadRequest,
 	errInvalidRevisionType:                      fasthttp.StatusBadRequest,
-	errFailedToReadRequestBody:                  http.StatusBadRequest,
+	errFailedToReadRequestBody:                  fasthttp.StatusBadRequest,
 }
 
 // ErrorResponse is the form used for API responses from failures in the API.

--- a/internal/platform/web/routes.go
+++ b/internal/platform/web/routes.go
@@ -43,8 +43,8 @@ func API(log restql.Logger, cfg *conf.Config) (fasthttp.RequestHandler, error) {
 	executor := runner.NewExecutor(log, client, cfg.HTTP.QueryResourceTimeout, cfg.HTTP.ForwardPrefix)
 	r := runner.NewRunner(log, executor, runner.Options{
 		GlobalQueryTimeout:      cfg.HTTP.GlobalQueryTimeout,
-		MaxConcurrentQueries:    cfg.HTTP.MaxConcurrentQueries,
-		MaxConcurrentGoroutines: cfg.HTTP.MaxConcurrentGoroutines,
+		MaxConcurrentQueries:    cfg.HTTP.Client.MaxConcurrentQueries,
+		MaxConcurrentGoroutines: cfg.HTTP.Client.MaxConcurrentGoroutines,
 	})
 
 	mappingReader := persistence.NewMappingReader(log, cfg.Env, cfg.TenantMappings, db)

--- a/internal/platform/web/routes.go
+++ b/internal/platform/web/routes.go
@@ -41,7 +41,11 @@ func API(log restql.Logger, cfg *conf.Config) (fasthttp.RequestHandler, error) {
 
 	client := httpclient.New(log, lifecycle, cfg)
 	executor := runner.NewExecutor(log, client, cfg.HTTP.QueryResourceTimeout, cfg.HTTP.ForwardPrefix)
-	r := runner.NewRunner(log, executor, cfg.HTTP.GlobalQueryTimeout)
+	r := runner.NewRunner(log, executor, runner.Options{
+		GlobalQueryTimeout:      cfg.HTTP.GlobalQueryTimeout,
+		MaxConcurrentQueries:    cfg.HTTP.MaxConcurrentQueries,
+		MaxConcurrentGoroutines: cfg.HTTP.MaxConcurrentGoroutines,
+	})
 
 	mappingReader := persistence.NewMappingReader(log, cfg.Env, cfg.TenantMappings, db)
 	tenantCache := cache.New(log, cfg.Cache.Mappings.MaxSize,

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -249,7 +249,7 @@ func (rw *requestWorker) Run() {
 					writeResult(rw.ctx, rw.resultCh, r)
 				})
 			case []interface{}:
-				go rw.runMultiplexedStatement(statement, resourceID)
+				rw.runMultiplexedStatement(statement, resourceID)
 			}
 		case <-rw.ctx.Done():
 			return
@@ -258,42 +258,55 @@ func (rw *requestWorker) Run() {
 }
 
 func (rw *requestWorker) runMultiplexedStatement(statements []interface{}, resourceID domain.ResourceID) {
-	responseChans := make([]chan interface{}, len(statements))
-	for i := range responseChans {
-		responseChans[i] = make(chan interface{}, 1)
-	}
-
-	var wg sync.WaitGroup
-
-	wg.Add(len(statements))
-	for i, stmt := range statements {
+	success := rw.goroutineLimiter.Acquire()
+	if !success {
 		select {
+		case rw.errorCh <- ErrMaxGoroutineDenied:
 		case <-rw.ctx.Done():
-			return
-		default:
 		}
 
-		i, stmt := i, stmt
-		ch := responseChans[i]
+		return
+	}
 
-		switch stmt := stmt.(type) {
-		case domain.Statement:
-			rw.runStatement(stmt, resourceID, func(r result) {
-				ch <- r.Response
-				wg.Done()
-			})
-		case []interface{}:
-			rw.runMultiplexedStatement(stmt, resourceID)
+	go func() {
+		responseChans := make([]chan interface{}, len(statements))
+		for i := range responseChans {
+			responseChans[i] = make(chan interface{}, 1)
 		}
-	}
 
-	wg.Wait()
-	responses := make(restql.DoneResources, len(statements))
-	for i, ch := range responseChans {
-		responses[i] = <-ch
-	}
+		var wg sync.WaitGroup
 
-	writeResult(rw.ctx, rw.resultCh, result{ResourceIdentifier: resourceID, Response: responses})
+		wg.Add(len(statements))
+		for i, stmt := range statements {
+			select {
+			case <-rw.ctx.Done():
+				return
+			default:
+			}
+
+			i, stmt := i, stmt
+			ch := responseChans[i]
+
+			switch stmt := stmt.(type) {
+			case domain.Statement:
+				rw.runStatement(stmt, resourceID, func(r result) {
+					ch <- r.Response
+					wg.Done()
+				})
+			case []interface{}:
+				rw.runMultiplexedStatement(stmt, resourceID)
+			}
+		}
+
+		wg.Wait()
+		responses := make(restql.DoneResources, len(statements))
+		for i, ch := range responseChans {
+			responses[i] = <-ch
+		}
+
+		writeResult(rw.ctx, rw.resultCh, result{ResourceIdentifier: resourceID, Response: responses})
+		rw.goroutineLimiter.Release()
+	}()
 }
 
 func (rw *requestWorker) runStatement(statement domain.Statement, resourceID domain.ResourceID, cb func(result)) {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -269,6 +269,8 @@ func (rw *requestWorker) runMultiplexedStatement(statements []interface{}, resou
 	}
 
 	go func() {
+		defer rw.goroutineLimiter.Release()
+
 		responseChans := make([]chan interface{}, len(statements))
 		for i := range responseChans {
 			responseChans[i] = make(chan interface{}, 1)
@@ -305,7 +307,6 @@ func (rw *requestWorker) runMultiplexedStatement(statements []interface{}, resou
 		}
 
 		writeResult(rw.ctx, rw.resultCh, result{ResourceIdentifier: resourceID, Response: responses})
-		rw.goroutineLimiter.Release()
 	}()
 }
 


### PR DESCRIPTION
This PR introduces configuration parameters to limit concurrency queries and goroutines (used to run queries), in order to avoid unbound goroutine and memory usage growth.