### PR TITLE
Improve restQL debugging: feature toggles and new strategy

### DIFF
--- a/docs/restql/config.md
+++ b/docs/restql/config.md
@@ -141,7 +141,7 @@ Due to the traffic restQL is designed to handle it takes a conservative approach
 
 ## Debugging
 
-RestQL supports a debug mode where its response verbosity is increased to include details about the HTTP request made to the upstream API resource. Currently, restQL support debug activation through a query parameter or header. By default, debugging with a query parameter is enabled. You can customize this with the following parameters in the configuration file or environment variables:
+RestQL supports a debug mode where its response verbosity is increased to include details about the HTTP request made to the upstream API resource. Currently, it supports debug activation through a query parameter and/or header. By default, debugging with a query parameter is enabled. You can customize this with the following parameters in the configuration file or environment variables:
 
 - `debugging.queryParam` or `RESTQL_DEBUGGING_QUERY_PARAM`: enables debugging using the `_debug` query param, `true` by default.
 - `debugging.header` or `RESTQL_DEBUGGING_HEADER`: enables debugging using the `X-Restql-Debug` header, `false` by default.

--- a/docs/restql/config.md
+++ b/docs/restql/config.md
@@ -139,6 +139,13 @@ Due to the traffic restQL is designed to handle it takes a conservative approach
 - `logging.timestamp`: boolean value that indicate with a timestamp field should be added to the log entry.
 - `logging.level`: the minimum log level required for a log entry to be output. You can see the list of available levels on the [zerolog documentation](https://github.com/rs/zerolog#leveled-logging).
 
+## Debugging
+
+RestQL supports a debug mode where its response verbosity is increased to include details about the HTTP request made to the upstream API resource. Currently, restQL support debug activation through a query parameter or header. By default, debugging with a query parameter is enabled. You can customize this with the following parameters in the configuration file or environment variables:
+
+- `debugging.queryParam` or `RESTQL_DEBUGGING_QUERY_PARAM`: enables debugging using the `_debug` query param, `true` by default.
+- `debugging.header` or `RESTQL_DEBUGGING_HEADER`: enables debugging using the `X-Restql-Debug` header, `false` by default.
+
 ## Alternative storage for mappings and queries
 
 To understand others stores besides a database for mappings and queries please refer to [Resource Mappings](/restql/resource-mappings.md) and [Running Queries](/restql/running-queries.md) pages.

--- a/docs/restql/troubleshooting.md
+++ b/docs/restql/troubleshooting.md
@@ -2,7 +2,7 @@
 
 If you're having problems invoking the underlying resource, restQL offers a debug option which will give more details about the resource restQL is trying to call, including the called URL and its parameters. 
 
-To enable debug mode add the query parameter `_debug=true` in your request. E.g.:
+The debug mode can be activated through the `_debug=true` query param or the `X-Restql-Debug: true` header, depending on the configuration.
 
 ```bash
 curl -d "from planets as allPlanets" -H "Content-Type: text/plain" localhost:9000/run-query?_debug=true  

--- a/docs/restql/troubleshooting.md
+++ b/docs/restql/troubleshooting.md
@@ -2,7 +2,7 @@
 
 If you're having problems invoking the underlying resource, restQL offers a debug option which will give more details about the resource restQL is trying to call, including the called URL and its parameters. 
 
-The debug mode can be activated through the `_debug=true` query param or the `X-Restql-Debug: true` header, depending on the configuration.
+The debug mode can be activated through the `_debug=true` query param and/or the `X-Restql-Debug: true` header, depending on the configuration.
 
 ```bash
 curl -d "from planets as allPlanets" -H "Content-Type: text/plain" localhost:9000/run-query?_debug=true  

--- a/internal/platform/conf/conf.go
+++ b/internal/platform/conf/conf.go
@@ -84,6 +84,11 @@ type Config struct {
 		} `yaml:"client"`
 	} `yaml:"http"`
 
+	Debugging struct {
+		QueryParam bool `yaml:"queryParam" env:"RESTQL_DEBUGGING_QUERY_PARAM"`
+		Header     bool `yaml:"header" env:"RESTQL_DEBUGGING_HEADER"`
+	} `yaml:"debugging"`
+
 	Logging struct {
 		Enable               bool   `yaml:"enable" env:"RESTQL_LOGGING_ENABLE"`
 		TimestampFieldName   string `yaml:"timestampFieldName"`

--- a/internal/platform/conf/yaml-defaults.go
+++ b/internal/platform/conf/yaml-defaults.go
@@ -23,6 +23,9 @@ http:
     maxIdleConnectionsPerHost: 512
     maxIdleConnectionDuration: 10s
 
+debugging:
+  queryParam: true
+
 logging:
   enable: true
   timestampFieldName: timestamp

--- a/internal/platform/web/restql.go
+++ b/internal/platform/web/restql.go
@@ -233,36 +233,46 @@ const debugHeaderName = "X-Restql-Debug"
 
 func isDebugEnabled(cfg *conf.Config, queryInput restql.QueryInput) bool {
 	switch {
+	case cfg.Debugging.Header && cfg.Debugging.QueryParam:
+		return extractDebugFromHeader(queryInput) || extractDebugFromQuery(queryInput)
 	case cfg.Debugging.Header:
-		header, found := queryInput.Headers[debugHeaderName]
-		if !found {
-			return false
-		}
-
-		d, err := strconv.ParseBool(header)
-		if err != nil {
-			return false
-		}
-
-		return d
+		return extractDebugFromHeader(queryInput)
 	case cfg.Debugging.QueryParam:
-		param, found := queryInput.Params[debugParamName]
-		if !found {
-			return false
-		}
-
-		debug, ok := param.(string)
-		if !ok {
-			return false
-		}
-
-		d, err := strconv.ParseBool(debug)
-		if err != nil {
-			return false
-		}
-
-		return d
+		return extractDebugFromQuery(queryInput)
 	default: // Both flags disabled, hence debugging is disabled
 		return false
 	}
+}
+
+func extractDebugFromHeader(queryInput restql.QueryInput) bool {
+	header, found := queryInput.Headers[debugHeaderName]
+	if !found {
+		return false
+	}
+
+	d, err := strconv.ParseBool(header)
+	if err != nil {
+		return false
+	}
+
+	return d
+}
+
+func extractDebugFromQuery(queryInput restql.QueryInput) bool {
+	param, found := queryInput.Params[debugParamName]
+	if !found {
+		return false
+	}
+
+	debug, ok := param.(string)
+	if !ok {
+		return false
+	}
+
+	d, err := strconv.ParseBool(debug)
+	if err != nil {
+		return false
+	}
+
+	return d
 }


### PR DESCRIPTION
This PR introduces a new strategy to enable the verbose response from restQL using a HTTP header `X-Restql-Debug`.

It also adds feature toggles to enable/disable query param and header strategy for debug. To maintain backwards compatibility the query param strategy is enabled by default.